### PR TITLE
セル削除時のクラッシュを修正

### DIFF
--- a/DHAB/Controller/BudgetViewController.swift
+++ b/DHAB/Controller/BudgetViewController.swift
@@ -10,7 +10,7 @@ import UIKit
 import RealmSwift
 
 protocol BudgetViewControllerDelegate{
-    func updateList()
+    func budgetViewControllerDidChangeBudget()
 }
 
 class BudgetViewController: UIViewController{
@@ -80,18 +80,18 @@ class BudgetViewController: UIViewController{
     }
     
     func dayBack(){
-        budgetViewControllerDelegate = self
+//        budgetViewControllerDelegate = self
         date = Calendar.current.date(byAdding: .month, value: -1, to:date)!
         dateLabel.text = dateFormatter.string(from: date)
-        self.budgetViewControllerDelegate?.updateList()
+        self.budgetViewControllerDelegate?.budgetViewControllerDidChangeBudget()
         budgetTableView.reloadData()
     }
     
     func dayPass(){
-        budgetViewControllerDelegate = self
+//        budgetViewControllerDelegate = self
         date = Calendar.current.date(byAdding: .month, value: 1, to:date)!
         dateLabel.text = dateFormatter.string(from: date)
-        self.budgetViewControllerDelegate?.updateList()
+        self.budgetViewControllerDelegate?.budgetViewControllerDidChangeBudget()
         budgetTableView.reloadData()
     }
     
@@ -198,6 +198,17 @@ class BudgetViewController: UIViewController{
             incomeBudgetTableView.reloadData()
         }
     }
+    
+    func updateList() {
+        setPaymentBudgetData()
+        setCategoryData()
+        budgetTableViewDataSource = []
+        incomeBudgetTableViewDataSource = []
+        setBudgetTableViewDataSourse()
+        setIncomeBudgetTableViewDataSourse()
+        view.layoutIfNeeded()
+        view.updateConstraints()
+    }
 }
 
 extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
@@ -240,7 +251,7 @@ extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         if tableView.tag == 0{
             _ = budgetTableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! BudgetTableViewCell
-            budgetViewControllerDelegate = self
+//            budgetViewControllerDelegate = self
             
             let alert = UIAlertController(title:"予算を変更します", message: nil, preferredStyle: .alert)
             
@@ -260,7 +271,8 @@ extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
                         budget.budgetPrice = Int(textFieldOnAlert.text!)!
                     }
                 }
-                self.budgetViewControllerDelegate?.updateList()
+                
+                self.budgetViewControllerDelegate?.budgetViewControllerDidChangeBudget()
             })
             
             let cancel = UIAlertAction(title:"キャンセル", style: .default, handler:{(action) -> Void in
@@ -272,7 +284,7 @@ extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
             self.present(alert,animated: true, completion: nil)
         }else if tableView.tag == 1{
             _ = incomeBudgetTableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! BudgetTableViewCell
-            budgetViewControllerDelegate = self
+//            budgetViewControllerDelegate = self
             let alert = UIAlertController(title:"予算を変更します", message: nil, preferredStyle: .alert)
             
             var textFieldOnAlert = UITextField()
@@ -289,7 +301,9 @@ extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
                         budget.budgetPrice = Int(textFieldOnAlert.text!)!
                     }
                 }
-                self.budgetViewControllerDelegate?.updateList()
+                
+                self.updateList()
+                self.budgetViewControllerDelegate?.budgetViewControllerDidChangeBudget()
             })
             
             let cancel = UIAlertAction(title:"キャンセル", style: .default, handler:{(action) -> Void in
@@ -302,18 +316,18 @@ extension BudgetViewController:UITableViewDelegate,UITableViewDataSource{
     }
 }
 
-extension BudgetViewController:BudgetViewControllerDelegate{
-    func updateList(){
-        setPaymentBudgetData()
-        setCategoryData()
-        budgetTableViewDataSource = []
-        incomeBudgetTableViewDataSource = []
-        setBudgetTableViewDataSourse()
-        setIncomeBudgetTableViewDataSourse()
-        view.layoutIfNeeded()
-        view.updateConstraints()
-    }
-}
+//extension BudgetViewController: BudgetViewControllerDelegate {
+//    func updateList(){
+//        setPaymentBudgetData()
+//        setCategoryData()
+//        budgetTableViewDataSource = []
+//        incomeBudgetTableViewDataSource = []
+//        setBudgetTableViewDataSourse()
+//        setIncomeBudgetTableViewDataSourse()
+//        view.layoutIfNeeded()
+//        view.updateConstraints()
+//    }
+//}
 
 extension BudgetViewController:BudgetConfigureViewControllerDelegate{
     func updateBudget(){

--- a/DHAB/Controller/ExpenseItemViewController.swift
+++ b/DHAB/Controller/ExpenseItemViewController.swift
@@ -194,7 +194,10 @@ extension ExpenseItemViewController: UITableViewDelegate,UITableViewDataSource{
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if tableView.tag == 0{
             let cell = expenseItemTableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-            cell.textLabel!.text = categoryList[indexPath.row].name
+            
+            let title = categoryList[indexPath.row].name
+            
+            cell.textLabel!.text = title
             return cell
         }else if tableView.tag == 1{
             let cell = incomeTableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
@@ -257,16 +260,19 @@ extension ExpenseItemViewController: UITableViewDelegate,UITableViewDataSource{
     }
     
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if tableView.tag == 0{
+        if tableView.tag == 0 {
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+            
             let targetItem = categoryList[indexPath.row]
+            categoryList.remove(at: indexPath.row)
+            
             let realm = try! Realm()
             try! realm.write{
                 realm.delete(targetItem)
             }
-            categoryList.remove(at: indexPath.row)
+            
             categoryViewControllerDelegate?.updateHouseholdAccountBook()
-            tableView.deleteRows(at: [indexPath], with: .automatic)
-        }else if tableView.tag == 1{
+        } else if tableView.tag == 1 {
             let targetItem = incomeCategoryList[indexPath.row]
             let realm = try! Realm()
             try! realm.write{

--- a/DHAB/Controller/HouseholdAccountBookViewController.swift
+++ b/DHAB/Controller/HouseholdAccountBookViewController.swift
@@ -15,7 +15,7 @@ protocol HouseholdAccountBookControllerDelegate{
     func updateIncome()
 }
 
-class HouseholdAccountBookViewController:UIViewController{
+class HouseholdAccountBookViewController:UIViewController {
     
     private var date = Date()
     @IBOutlet weak var dayLabel: UILabel!
@@ -701,11 +701,14 @@ extension HouseholdAccountBookViewController:UITableViewDelegate,UITableViewData
                     returnView()
                 }
             case 1:
+                // メニュー > 予算
                 let storyboard = UIStoryboard(name: "BudgetViewController", bundle: nil)
-                let navigationController = storyboard.instantiateViewController(withIdentifier: "NavigationController") as! UINavigationController
+                let budgetViewController = storyboard.instantiateViewController(withIdentifier: "BudgetViewController") as! BudgetViewController
+                budgetViewController.budgetViewControllerDelegate = self
                 
-//                navigationController.budgetViewControllerDelegate = self
-                present(navigationController,animated: true)
+                let nav = UINavigationController(rootViewController: budgetViewController)
+                present(nav,animated: true)
+                
                 returnView()
             default:
                 return
@@ -750,5 +753,11 @@ extension HouseholdAccountBookViewController:CategoryViewControllerDelegate{
         setIncomeTableViewDataSourse()
         setSumIncomeData()
         setMonthSumIncome()
+    }
+}
+
+extension HouseholdAccountBookViewController: BudgetViewControllerDelegate {
+    func budgetViewControllerDidChangeBudget() {
+        print("hkr updateList")
     }
 }

--- a/DHAB/View/BudgetViewController.storyboard
+++ b/DHAB/View/BudgetViewController.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="ie6-KJ-iG7">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -10,26 +10,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Navigation Controller-->
-        <scene sceneID="unb-7x-tF8">
-            <objects>
-                <navigationController storyboardIdentifier="NavigationController" id="ie6-KJ-iG7" sceneMemberID="viewController">
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="jlS-4Z-2ss">
-                        <rect key="frame" x="0.0" y="59" width="393" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="Y6W-OH-hqX" kind="relationship" relationship="rootViewController" id="ol0-np-2sK"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="ND8-c2-JYw" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="-613" y="-2"/>
-        </scene>
         <!--Budget View Controller-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
-                <viewController id="Y6W-OH-hqX" customClass="BudgetViewController" customModule="DHAB" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="BudgetViewController" id="Y6W-OH-hqX" customClass="BudgetViewController" customModule="DHAB" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -51,7 +35,7 @@
                                 </connections>
                             </button>
                             <navigationBar contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MiR-Ip-r7S">
-                                <rect key="frame" x="0.0" y="103" width="393" height="44"/>
+                                <rect key="frame" x="0.0" y="59" width="393" height="88"/>
                             </navigationBar>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="R3R-66-kYe">
                                 <rect key="frame" x="0.0" y="177.33333333333331" width="393" height="640.66666666666674"/>

--- a/DHAB/View/customCell/ResultTableViewCell.xib
+++ b/DHAB/View/customCell/ResultTableViewCell.xib
@@ -11,14 +11,14 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" reuseIdentifier="customCell" rowHeight="75" id="KGk-i7-Jjw" customClass="ResultTableViewCell" customModule="DHAB" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="320" height="75"/>
+            <rect key="frame" x="0.0" y="0.0" width="298" height="75"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="KGk-i7-Jjw" id="H2p-sc-9uM">
-                <rect key="frame" x="0.0" y="0.0" width="320" height="75"/>
+                <rect key="frame" x="0.0" y="0.0" width="298" height="75"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="26J-jd-TQ8">
-                        <rect key="frame" x="0.0" y="0.0" width="320" height="75"/>
+                        <rect key="frame" x="0.0" y="0.0" width="298" height="75"/>
                         <subviews>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="date" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1jO-S9-q6U">
                                 <rect key="frame" x="0.0" y="0.0" width="60" height="75"/>
@@ -42,7 +42,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Egb-Dx-e6U">
-                                <rect key="frame" x="210" y="0.0" width="110" height="75"/>
+                                <rect key="frame" x="188" y="0.0" width="110" height="75"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7l6-LC-140">
                                         <rect key="frame" x="0.0" y="0.0" width="110" height="49.666666666666664"/>
@@ -130,7 +130,7 @@
                 <outlet property="paymentLabel" destination="clH-k1-pJE" id="5Qn-M7-Anh"/>
                 <outlet property="resultLabel" destination="J2J-g0-4Zl" id="ybM-eh-KxH"/>
             </connections>
-            <point key="canvasLocation" x="80.916030534351137" y="8.8028169014084519"/>
+            <point key="canvasLocation" x="97.70992366412213" y="8.8028169014084519"/>
         </tableViewCell>
     </objects>
 </document>


### PR DESCRIPTION
# 対応内容
- TableViewに表示している配列に、表示している日付の支出のみ格納するようにした
- TableViewに表示している配列をセル生成時、選択時に使いまわすようにした

# 補足
色々差分が出てしまってますが、`CalendarViewController`だけ確認していただければと思います。